### PR TITLE
Add string for Esperanto option in Keyboard

### DIFF
--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -1030,6 +1030,7 @@
     <string name="translation_bulgarian">Bulgarian</string>
     <string name="translation_catalan">Catalan</string>
     <string name="translation_czech">Czech</string>
+    <string name="translation_esperanto">Esperanto</string>
     <string name="translation_welsh">Welsh</string>
     <string name="translation_danish">Danish</string>
     <string name="translation_english">English</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [X] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
Added string for Esperanto option in Keyboard. This is for https://github.com/FossifyOrg/Keyboard/pull/35

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Commons/blob/master/CONTRIBUTING.md).
