### PR TITLE
Fix ArrayIndexOutOfBoundsException in formatSize() on huge sizes

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/extensions/Long.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/Long.kt
@@ -7,11 +7,12 @@ import java.util.Calendar
 import java.util.Locale
 
 fun Long.formatSize(): String {
+    // https://stackoverflow.com/a/5599842
     if (this <= 0) {
         return "0 B"
     }
 
-    val units = arrayOf("B", "kB", "MB", "GB", "TB")
+    val units = arrayOf("B", "kB", "MB", "GB", "TB", "PB", "EB")
     val digitGroups = (Math.log10(toDouble()) / Math.log10(1024.0)).toInt()
     return "${DecimalFormat("#,##0.#").format(this / Math.pow(1024.0, digitGroups.toDouble()))} ${units[digitGroups]}"
 }


### PR DESCRIPTION
Previously it would crash on sizes greater than ~1.2e15 (1024 TB). By adding two more units, it will work on all possible Long values.

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Fix ArrayIndexOutOfBoundsException in formatSize() on huge sizes
- Make Int.formatSize() a simple wrapper for Long.formatSize() to avoid code repetition
- Add attribution, because the code appears to have been copied from https://stackoverflow.com/posts/5599842/revisions#rev-body-85411f2d-9228-4768-9a7f-04c6d392a385

#### Fixes the following issue(s)
Not tracked

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Commons/blob/master/CONTRIBUTING.md).
