### PR TITLE
Update Kotlin to 1.9.23 to fix broken build

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 #jetbrains
-kotlin = "1.9.22"
+kotlin = "1.9.23"
 kotlin-immutable-collections = "0.3.6"
 #KSP
 kotlinxSerializationJson = "1.5.1"
-ksp = "1.9.22-1.0.17"
+ksp = "1.9.23-1.0.19"
 #Androidx
 androidx-customView = "1.2.0-alpha02"
 androidx-customViewPooling = "1.0.0"


### PR DESCRIPTION
This fixes the build after the recent update of the Composer Compiler:

> e: This version (1.5.11) of the Compose Compiler requires Kotlin version 1.9.23 but you appear to be using Kotlin version 1.9.22 which is not known to be compatible.  Please consult the Compose-Kotlin compatibility map located at https://developer.android.com/jetpack/androidx/releases/compose-kotlin to choose a compatible version pair (or `suppressKotlinVersionCompatibilityCheck` but don't say I didn't warn you!).

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Update Kotlin to 1.9.23

#### Fixes the following issue(s)
Not tracked

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Commons/blob/master/CONTRIBUTING.md).
