### PR TITLE
Fix project's group configuration

### DIFF
--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -7,7 +7,12 @@ plugins {
     `maven-publish`
 }
 
+group = "org.fossify"
+version = "1.0.0"
+
 android {
+    namespace = "org.fossify.commons"
+
     compileSdk = libs.versions.app.build.compileSDKVersion.get().toInt()
 
     defaultConfig {
@@ -59,14 +64,10 @@ android {
     sourceSets {
         getByName("main").java.srcDirs("src/main/kotlin")
     }
-    namespace = libs.versions.app.version.groupId.get()
 }
 
 publishing.publications {
     create<MavenPublication>("release") {
-        groupId = libs.versions.app.version.groupId.get()
-        artifactId = name
-        version = libs.versions.app.version.versionName.get()
         afterEvaluate {
             from(components["release"])
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,11 +50,6 @@ app-build-targetSDK = "34"
 app-build-minimumSDK = "23"
 app-build-javaVersion = "VERSION_17"
 app-build-kotlinJVMTarget = "17"
-#versioning
-app-version-groupId = "org.fossify.commons"
-app-version-appId = "org.fossify.commons.samples"
-app-version-versionCode = "1"
-app-version-versionName = "1.0.0"
 [libraries]
 #Android X
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }

--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -3,14 +3,16 @@ plugins {
     alias(libs.plugins.kotlinAndroid)
 }
 android {
+    namespace = "org.fossify.commons.samples"
+
     compileSdk = libs.versions.app.build.compileSDKVersion.get().toInt()
 
     defaultConfig {
-        applicationId = libs.versions.app.version.appId.get()
+        applicationId = "org.fossify.commons.samples"
         minSdk = libs.versions.app.build.minimumSDK.get().toInt()
         targetSdk = libs.versions.app.build.targetSDK.get().toInt()
-        versionName = libs.versions.app.version.versionName.get()
-        versionCode = libs.versions.app.version.versionCode.get().toInt()
+        versionCode = 1
+        versionName = "1.0.0"
         vectorDrawables.useSupportLibrary = true
     }
 
@@ -62,7 +64,6 @@ android {
     sourceSets {
         getByName("main").java.srcDirs("src/main/kotlin")
     }
-    namespace = "org.fossify.commons.samples"
 
     lint {
         disable.add("Instantiatable")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,4 +15,4 @@ dependencyResolutionManagement {
 }
 rootProject.name = "Fossify-Commons"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
-include(":samples", "commons")
+include(":commons", ":samples")


### PR DESCRIPTION
The configuration was incorrect. The JitPack build still worked, but publishing to the Maven local repository using
`./gradlew publishToMavenLocal` was broken (incorrect paths and metadata), and composite builds didn't get automatic dependency substitution: building other apps against a local version of Commons using `./gradlew --include-build=../Commons ...` didn't work, and using `includeBuild("../Commons")` in <app>/settings.gradle.kts only worked with a manual substitution directive[1].

Also move project identity values out of gradle/libs.versions.toml.

[1] https://github.com/FossifyOrg/Gallery/blob/692a5d08b30e7d4d374f53d7371781d05b482dc9/settings.gradle.kts#L26

#### What is it?
- [x] Bugfix
- [ ] Feature
- [x] Codebase improvement

#### Description of the changes in your PR

- Fix the Maven groupId (it should be "org.fossify", not "org.fossify.commons").

- Set the Gradle project group. This allows automatic dependency substitution in composite builds (`--include-build=../Commons`). Also set the Gradle project version for consistency.

- Use defaults for MavenPublication. (It's no longer necessary to explicitly set the Maven groupId/artifactId/version because they default to the Gradle project group/name/version. This also fixes the artifactId, which was previously "release" but should be "commons".)

- Avoid using libs.versions.toml for project identity. (That file is normally used for dependencies. Using it to set the project's own name and version is unusual. Also, it's confusing to have the "samples" project's appId and versionCode mixed together with the library things.)

- Move android.namespace declaration up (it's more logical and matches the official examples).

- Tweak the include() call in settings.gradle.kts (reorder so that "commons" is first because it's more important than "samples", and make colons consistent).

#### Fixes the following issue(s)
- Fixes FossifyOrg/General-Discussion#150.

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Commons/blob/master/CONTRIBUTING.md).
