### PR TITLE
Fix a display bug due to a too long translation

### DIFF
--- a/commons/src/main/res/values-fr/strings.xml
+++ b/commons/src/main/res/values-fr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="ok">Valider</string>
+    <string name="ok">OK</string>
     <string name="cancel">Annuler</string>
     <string name="close">Fermer</string>
     <string name="back">Retour</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Update strings

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes FossifyOrg/AppRepo" so that GitHub closes them when this PR is merged (note that each "Fixes #" should be in its own item). For Commons, it should always be in a format like "Fixes FossifyOrg/AppRepo#123" -->
The objective of this PR is not really to update the translations but to fix a bug that occurs in Fossify Gallery. Using the Material You theme, there is not enough space to display all the translations of "Other folder", "Cancel" and "OK" on some devices, so the three buttons are displayed below each other, which is neither practical nor beautiful. So I shortened one of the strings by replacing it with its previous translation. Most devices should now be able to display everything.
![image131](https://github.com/FossifyOrg/Commons/assets/146990829/984203b0-402e-4018-93f9-b4441a76b2ac)

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Commons/blob/master/CONTRIBUTING.md).
