### PR TITLE
Added tranlsation_belarusian string

### DIFF
--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -1033,6 +1033,7 @@
 
     <string name="translation_arabic">Arabic</string>
     <string name="translation_azerbaijani">Azerbaijani</string>
+    <string name="translation_belarusian">Belarusan</string>
     <string name="translation_bengali">Bengali</string>
     <string name="translation_breton">Breton</string>
     <string name="translation_bulgarian">Bulgarian</string>


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Update strings

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Commons/blob/master/CONTRIBUTING.md).

P. S. „Belarusan“ (without the 'i') is not a mistake or typo. This is how the old Belarusan diaspora writes (or wrote), and it is also how the Belarusan linguist Vincuk Viačorka recommends to write it.