### PR TITLE
Add configuration and helper methods related to day of week

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
@@ -49,6 +49,7 @@ import org.fossify.commons.helpers.*
 import org.fossify.commons.helpers.MyContentProvider.PERMISSION_WRITE_GLOBAL_SETTINGS
 import org.fossify.commons.models.AlarmSound
 import org.fossify.commons.models.BlockedNumber
+import org.joda.time.DateTimeConstants
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -1258,4 +1259,19 @@ fun Context.openFullScreenIntentSettings(appId: String) {
         intent.data = uri
         startActivity(intent)
     }
+}
+
+fun Context.getDayOfWeekString(dayOfWeek: Int): String {
+    val dayOfWeekResId = when (dayOfWeek) {
+        DateTimeConstants.MONDAY -> org.fossify.commons.R.string.monday
+        DateTimeConstants.TUESDAY -> org.fossify.commons.R.string.tuesday
+        DateTimeConstants.WEDNESDAY -> org.fossify.commons.R.string.wednesday
+        DateTimeConstants.THURSDAY -> org.fossify.commons.R.string.thursday
+        DateTimeConstants.FRIDAY -> org.fossify.commons.R.string.friday
+        DateTimeConstants.SATURDAY -> org.fossify.commons.R.string.saturday
+        DateTimeConstants.SUNDAY -> org.fossify.commons.R.string.sunday
+        else -> throw IllegalArgumentException("Invalid day: $dayOfWeek")
+    }
+
+    return getString(dayOfWeekResId)
 }

--- a/commons/src/main/kotlin/org/fossify/commons/extensions/List.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/List.kt
@@ -1,5 +1,7 @@
 package org.fossify.commons.extensions
 
+import java.util.Collections
+
 fun List<String>.getMimeType(): String {
     val mimeGroups = HashSet<String>(size)
     val subtypes = HashSet<String>(size)
@@ -19,3 +21,13 @@ fun List<String>.getMimeType(): String {
         else -> "*/*"
     }
 }
+
+fun <T> List<T>.rotate(distance: Int): List<T> {
+    return toMutableList().apply {
+        Collections.rotate(this, distance)
+    }
+}
+
+fun <T> List<T>.rotateRight(distance: Int) = rotate(distance)
+
+fun <T> List<T>.rotateLeft(distance: Int) = rotate(-distance)

--- a/commons/src/main/kotlin/org/fossify/commons/helpers/BaseConfig.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/helpers/BaseConfig.kt
@@ -605,6 +605,14 @@ open class BaseConfig(val context: Context) {
         get() = prefs.getLong(PASSWORD_COUNTDOWN_START_MS, 0L)
         set(passwordCountdownStartMs) = prefs.edit().putLong(PASSWORD_COUNTDOWN_START_MS, passwordCountdownStartMs).apply()
 
+    // Returns the first day of week, indexing follows ISO 8601: Mon=1, ..., Sun=7
+    var firstDayOfWeek: Int
+        get() {
+            val defaultFirstDayOfWeek = Calendar.getInstance(Locale.getDefault()).firstDayOfWeek
+            return prefs.getInt(FIRST_DAY_OF_WEEK, getISODayOfWeekFromJava(defaultFirstDayOfWeek))
+        }
+        set(firstDayOfWeek) = prefs.edit().putInt(FIRST_DAY_OF_WEEK, firstDayOfWeek).apply()
+
     // Accessibility
     var showCheckmarksOnSwitches: Boolean
         get() = prefs.getBoolean(SHOW_CHECKMARKS_ON_SWITCHES, false)

--- a/commons/src/main/kotlin/org/fossify/commons/helpers/Constants.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/helpers/Constants.kt
@@ -197,6 +197,7 @@ const val PASSWORD_COUNTDOWN_START_MS = "password_count_down_start_ms"
 const val LAST_UNLOCK_TIMESTAMP_MS = "last_unlock_timestamp_ms"
 const val UNLOCK_TIMEOUT_DURATION_MS = "unlock_timeout_duration_ms"
 const val SHOW_CHECKMARKS_ON_SWITCHES = "show_checkmarks_on_switches"
+const val FIRST_DAY_OF_WEEK = "first_day_of_week"
 
 const val MAX_PASSWORD_RETRY_COUNT = 3
 const val DEFAULT_PASSWORD_COUNTDOWN = 5

--- a/commons/src/main/kotlin/org/fossify/commons/helpers/Constants.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/helpers/Constants.kt
@@ -12,6 +12,7 @@ import org.fossify.commons.R
 import org.fossify.commons.extensions.normalizeString
 import org.fossify.commons.models.contacts.LocalContact
 import org.fossify.commons.overloads.times
+import org.joda.time.DateTimeConstants
 
 const val EXTERNAL_STORAGE_PROVIDER_AUTHORITY = "com.android.externalstorage.documents"
 const val EXTRA_SHOW_ADVANCED = "android.content.extra.SHOW_ADVANCED"
@@ -721,3 +722,23 @@ fun getProperText(text: String, shouldNormalize: Boolean) =
         shouldNormalize -> text.normalizeString()
         else -> text
     }
+
+fun getISODayOfWeekFromJava(javaDayOfWeek: Int): Int {
+    if (javaDayOfWeek !in 1..7) {
+        throw IllegalArgumentException("Invalid Java day of week: $javaDayOfWeek")
+    }
+
+    // Java: Sun=1, ..., Sat=7
+    // ISO:  Mon=1, ..., Sun=7
+    return (javaDayOfWeek + 5) % 7 + 1
+}
+
+fun getJavaDayOfWeekFromISO(isoDayOfWeek: Int): Int {
+    if (isoDayOfWeek !in 1..7) {
+        throw IllegalArgumentException("Invalid ISO day of week: $isoDayOfWeek")
+    }
+
+    // ISO:  Mon=1, ..., Sun=7
+    // Java: Sun=1, ..., Sat=7
+    return (isoDayOfWeek % 7) + 1
+}


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix
- [ ] Feature
- [x] Codebase improvement

#### Description of the changes in your PR
- Added `firstDayOfWeek` config. It was originally introduced in Calendar (https://github.com/SimpleMobileTools/Simple-Calendar/pull/2159) but now it's also required in Clock (https://github.com/FossifyOrg/Clock/pull/59)
- Added helper methods for rotating items left and right (uses `Collections.rotate()` internally for simplicity). Calendar and Clock both use two different methods for this.
- Added helper methods to convert legacy java day of week to ISO8601 codes and vice versa. 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Commons/blob/master/CONTRIBUTING.md).
