### PR TITLE
Add task to build.gradle.kts for publishing to local m2 cache with gi…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.io.ByteArrayOutputStream
+
 plugins {
     alias(libs.plugins.android).apply(false)
     alias(libs.plugins.kotlinAndroid).apply(false)
@@ -8,6 +10,22 @@ plugins {
     alias(libs.plugins.detekt).apply(false)
 }
 
+tasks.register<Exec>("setVersionToGitCommitHash") {
+    val outputStream = ByteArrayOutputStream()
+    standardOutput = outputStream
+    workingDir = project.rootDir
+    commandLine = listOf("git", "rev-parse", "--short=10", "HEAD")
+    doLast {
+        val commitHash = outputStream.toString().trim()
+        project(":commons").version = commitHash
+    }
+}
+tasks.register("publishToMavenLocalWithCommitHash") {
+    group = "Publishing"
+    description = "Publish project to local maven cache with git commit hash as version"
+    dependsOn("setVersionToGitCommitHash")
+    dependsOn("commons:publishToMavenLocal")
+}
 tasks.register<Delete>("clean") {
     delete {
         layout.buildDirectory.asFile


### PR DESCRIPTION
…t commit hash.

A task to publish build artifacts to local maven cache with git commit hash as version. Those will be picked up by gradle during next dependency sync of the root project.

You must add mavenLocal() as last line to repositories of  dependencyResolutionManagement in settings.gradle.kts of your root project.

<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [X] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Added build task for to ease development

#### Relies on the following changes
<!-- Delete this if it doesn't apply to your PR. -->
- mavenLocal() repos must be enabled in root project.

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Commons/blob/master/CONTRIBUTING.md).
