### PR TITLE
Add an Int extension function to adjust sim color against dark background

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/extensions/Int.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/Int.kt
@@ -191,3 +191,12 @@ fun Int.countdown(intervalMillis: Long, callback: (count: Int) -> Unit) {
         (this - 1).countdown(intervalMillis, callback)
     }
 }
+
+fun Int.adjustSimColorForBackground(bg: Int): Int {
+    val hsv = FloatArray(3)
+    Color.colorToHSV(bg, hsv)
+    if (hsv[2] < 0.5) {
+        return this.lightenColor(24)
+    }
+    return this
+}


### PR DESCRIPTION


<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
Add an extension that brightens sim color against dark background to improve readability.

I intend to finish the PR FossifyOrg/Phone#27 which seemed to be abandoned since there was no update for over a year now. It was almost finished and was only needing to move the code included in this PR to an extension in the Commons repository since it can also be used in the Messages app. 

I hope this is OK, I will add a new PR in the Phone repository with the code to complete original PR.

Also, since the code added is not mine, I put a reference to the original commit in the commit message in order to credit the original author.

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Commons/blob/master/CONTRIBUTING.md).
