### PR TITLE
Added extension to format seconds to short time

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
@@ -601,7 +601,7 @@ fun Context.formatSecondsToShortTimeString(totalSeconds: Int): String {
     val timesString = StringBuilder()
     if (days > 0) {
         val daysString = String.format(resources.getString(R.string.days_short), days)
-        timesString.append("$daysString, ")
+        timesString.append("$daysString ")
     }
 
     if (hours > 0) {

--- a/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
@@ -611,7 +611,7 @@ fun Context.formatSecondsToShortTimeString(totalSeconds: Int): String {
 
     if (minutes > 0) {
         val minutesString = String.format(resources.getString(R.string.minutes_short), minutes)
-        timesString.append("$minutesString, ")
+        timesString.append("$minutesString ")
     }
 
     if (seconds > 0) {

--- a/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
@@ -606,7 +606,7 @@ fun Context.formatSecondsToShortTimeString(totalSeconds: Int): String {
 
     if (hours > 0) {
         val hoursString = String.format(resources.getString(R.string.hours_short), hours)
-        timesString.append("$hoursString, ")
+        timesString.append("$hoursString ")
     }
 
     if (minutes > 0) {

--- a/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
@@ -600,28 +600,28 @@ fun Context.formatSecondsToShortTimeString(totalSeconds: Int): String {
     val seconds = totalSeconds % MINUTE_SECONDS
     val timesString = StringBuilder()
     if (days > 0) {
-        val daysString = String.format(resources.getString(R.string.days_short), days)
+        val daysString = String.format(resources.getString(R.string.days_letter), days)
         timesString.append("$daysString ")
     }
 
     if (hours > 0) {
-        val hoursString = String.format(resources.getString(R.string.hours_short), hours)
+        val hoursString = String.format(resources.getString(R.string.hours_letter), hours)
         timesString.append("$hoursString ")
     }
 
     if (minutes > 0) {
-        val minutesString = String.format(resources.getString(R.string.minutes_short), minutes)
+        val minutesString = String.format(resources.getString(R.string.minutes_letter), minutes)
         timesString.append("$minutesString ")
     }
 
     if (seconds > 0) {
-        val secondsString = String.format(resources.getString(R.string.seconds_short), seconds)
+        val secondsString = String.format(resources.getString(R.string.seconds_letter), seconds)
         timesString.append(secondsString)
     }
 
     var result = timesString.toString().trim()
     if (result.isEmpty()) {
-        result = String.format(resources.getString(R.string.minutes_short), 0)
+        result = String.format(resources.getString(R.string.minutes_letter), 0)
     }
     return result
 }

--- a/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
@@ -591,6 +591,41 @@ fun Context.formatSecondsToTimeString(totalSeconds: Int): String {
     return result
 }
 
+fun Context.formatMinutesToShortTimeString(totalMinutes: Int) = formatSecondsToShortTimeString(totalMinutes * 60)
+
+fun Context.formatSecondsToShortTimeString(totalSeconds: Int): String {
+    val days = totalSeconds / DAY_SECONDS
+    val hours = (totalSeconds % DAY_SECONDS) / HOUR_SECONDS
+    val minutes = (totalSeconds % HOUR_SECONDS) / MINUTE_SECONDS
+    val seconds = totalSeconds % MINUTE_SECONDS
+    val timesString = StringBuilder()
+    if (days > 0) {
+        val daysString = String.format(resources.getString(R.string.days_short), days)
+        timesString.append("$daysString, ")
+    }
+
+    if (hours > 0) {
+        val hoursString = String.format(resources.getString(R.string.hours_short), hours)
+        timesString.append("$hoursString, ")
+    }
+
+    if (minutes > 0) {
+        val minutesString = String.format(resources.getString(R.string.minutes_short), minutes)
+        timesString.append("$minutesString, ")
+    }
+
+    if (seconds > 0) {
+        val secondsString = String.format(resources.getString(R.string.seconds_short), seconds)
+        timesString.append(secondsString)
+    }
+
+    var result = timesString.toString().trim().trimEnd(',')
+    if (result.isEmpty()) {
+        result = String.format(resources.getString(R.string.minutes_short), 0)
+    }
+    return result
+}
+
 fun Context.getFormattedMinutes(minutes: Int, showBefore: Boolean = true) = getFormattedSeconds(if (minutes == -1) minutes else minutes * 60, showBefore)
 
 fun Context.getFormattedSeconds(seconds: Int, showBefore: Boolean = true) = when (seconds) {

--- a/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
@@ -619,7 +619,7 @@ fun Context.formatSecondsToShortTimeString(totalSeconds: Int): String {
         timesString.append(secondsString)
     }
 
-    var result = timesString.toString().trim().trimEnd(',')
+    var result = timesString.toString().trim()
     if (result.isEmpty()) {
         result = String.format(resources.getString(R.string.minutes_short), 0)
     }

--- a/commons/src/main/res/values-be/strings.xml
+++ b/commons/src/main/res/values-be/strings.xml
@@ -447,9 +447,9 @@
     <string name="minutes_raw">хвілін</string>
     <string name="hours_raw">гадзін</string>
     <string name="days_raw">дзён</string>
-    <string name="seconds_letter">с</string>
-    <string name="minutes_letter">х</string>
-    <string name="hours_letter">г</string>
+    <string name="seconds_letter">%dс</string>
+    <string name="minutes_letter">%dх</string>
+    <string name="hours_letter">%dг</string>
     <plurals name="seconds">
         <item quantity="one">%d секунда</item>
         <item quantity="few">%d секунды</item>

--- a/commons/src/main/res/values-bg/strings.xml
+++ b/commons/src/main/res/values-bg/strings.xml
@@ -447,9 +447,9 @@
     <string name="minutes_raw">минути</string>
     <string name="hours_raw">часове</string>
     <string name="days_raw">дни</string>
-    <string name="seconds_letter">с</string>
-    <string name="minutes_letter">м</string>
-    <string name="hours_letter">ч</string>
+    <string name="seconds_letter">%dс</string>
+    <string name="minutes_letter">%dм</string>
+    <string name="hours_letter">%dч</string>
     <plurals name="seconds">
         <item quantity="one">%d секунда</item>
         <item quantity="other">%d секунди</item>

--- a/commons/src/main/res/values-bs/strings.xml
+++ b/commons/src/main/res/values-bs/strings.xml
@@ -482,7 +482,7 @@
     <string name="minutes_raw">minute</string>
     <string name="hours_raw">sati</string>
     <string name="days_raw">dani</string>
-    <string name="minutes_letter">min</string>
+    <string name="minutes_letter">%dmin</string>
     <string name="week_number_short">sed.</string>
     <plurals name="seconds">
         <item quantity="one">%d sekunda</item>

--- a/commons/src/main/res/values-ca/strings.xml
+++ b/commons/src/main/res/values-ca/strings.xml
@@ -1097,9 +1097,9 @@
     <string name="enter_password">Introduïu la contrasenya</string>
     <string name="password">Contrasenya</string>
     <string name="add_password">Afegeix una contrasenya</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">m</string>
-    <string name="hours_letter">h</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dm</string>
+    <string name="hours_letter">%dh</string>
     <string name="week_number_short">st.</string>
     <string name="purchase_simple_thank_you">Compra de Fossify Thank You</string>
     <string name="general_settings">General</string>

--- a/commons/src/main/res/values-cs/strings.xml
+++ b/commons/src/main/res/values-cs/strings.xml
@@ -1050,9 +1050,9 @@
     <string name="too_many_incorrect_attempts">Příliš mnoho nesprávných pokusů o odemknutí.
 \nZkuste to znovu za %d sekund.</string>
     <string name="enter_password">Zadejte heslo</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">m</string>
-    <string name="hours_letter">h</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dm</string>
+    <string name="hours_letter">%dh</string>
     <string name="week_number_short">týd.</string>
     <string name="purchase_simple_thank_you">Zakoupit Poděkování Fossify</string>
     <string name="notification_sound">Zvuk oznámení</string>

--- a/commons/src/main/res/values-da/strings.xml
+++ b/commons/src/main/res/values-da/strings.xml
@@ -449,7 +449,7 @@
     <string name="minutes_raw">minutter</string>
     <string name="hours_raw">timer</string>
     <string name="days_raw">dage</string>
-    <string name="hours_letter">t</string>
+    <string name="hours_letter">%dt</string>
     <string name="week_number_short">u.</string>
     <plurals name="seconds">
         <item quantity="one">%d sekund</item>

--- a/commons/src/main/res/values-de/strings.xml
+++ b/commons/src/main/res/values-de/strings.xml
@@ -473,9 +473,9 @@
     <string name="minutes_raw">Minuten</string>
     <string name="hours_raw">Stunden</string>
     <string name="days_raw">Tage</string>
-    <string name="seconds_letter">Sek.</string>
-    <string name="minutes_letter">Min.</string>
-    <string name="hours_letter">Std.</string>
+    <string name="seconds_letter">%dSek.</string>
+    <string name="minutes_letter">%dMin.</string>
+    <string name="hours_letter">%dStd.</string>
     <string name="week_number_short">KW</string>
     <plurals name="seconds">
         <item quantity="one">%d Sekunde</item>

--- a/commons/src/main/res/values-el/strings.xml
+++ b/commons/src/main/res/values-el/strings.xml
@@ -470,9 +470,9 @@
     <string name="minutes_raw">λεπτά</string>
     <string name="hours_raw">ώρες</string>
     <string name="days_raw">ημερ.</string>
-    <string name="seconds_letter">δ</string>
-    <string name="minutes_letter">λ</string>
-    <string name="hours_letter">ω</string>
+    <string name="seconds_letter">%dδ</string>
+    <string name="minutes_letter">%dλ</string>
+    <string name="hours_letter">%dω</string>
     <string name="week_number_short">εβδ.</string>
     <plurals name="seconds">
         <item quantity="one">%d δευτ.</item>

--- a/commons/src/main/res/values-eo/strings.xml
+++ b/commons/src/main/res/values-eo/strings.xml
@@ -625,9 +625,9 @@
     </plurals>
     <string name="minutes_raw">minutoj</string>
     <string name="days_raw">tagoj</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">m</string>
-    <string name="hours_letter">h</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dm</string>
+    <string name="hours_letter">%dh</string>
     <plurals name="seconds">
         <item quantity="one">%d sekundo</item>
         <item quantity="other">%d sekundoj</item>

--- a/commons/src/main/res/values-es/strings.xml
+++ b/commons/src/main/res/values-es/strings.xml
@@ -1107,9 +1107,9 @@
     <string name="enter_password">Introduzca la contraseña</string>
     <string name="password">Contraseña</string>
     <string name="add_password">Añadir una contraseña</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">min</string>
-    <string name="hours_letter">h</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dmin</string>
+    <string name="hours_letter">%dh</string>
     <string name="week_number_short">semana</string>
     <string name="general_settings">General</string>
     <string name="purchase_simple_thank_you">Comprar Fossify Thank You</string>

--- a/commons/src/main/res/values-et/strings.xml
+++ b/commons/src/main/res/values-et/strings.xml
@@ -1011,8 +1011,8 @@
     <string name="pro_app_refund">Palun arvesta, et kui eemaldad tasulise rakenduse nutiseadmest 2 tunni jooksul, siis ostusumma tagastatakse automaatselt. Kui soovit tagastust hiljem, siis saada e-kiri hello@fossify.org aadressile ning korraldame tagastuse. Mõlemal juhul on sul võimalik meie tasulisi rakendusi testida :)</string>
     <string name="developer_description">Arendame Androidi jaoks avatud lähtekoodil põhinevaid lihtsaid tarvikuid ja milles pole reklaame ega vajadust asjatute õiguste jaoks.</string>
     <string name="exif">EXIF</string>
-    <string name="minutes_letter">m</string>
-    <string name="hours_letter">t</string>
+    <string name="minutes_letter">%dm</string>
+    <string name="hours_letter">%dt</string>
     <string name="friday_letter">R</string>
     <string name="donate_new">Tere,&lt;br&gt;&lt;br&gt; loodame, et sulle meie rakendus meeldib. See ei sisalda reklaame, palun toeta selle arendamist, ostes rakenduse &lt;a href=https://play.google.com/store/apps/details?id=org.fossify.thankyou&gt;Fossify Suur Tänu&lt;/a&gt;. Seejärel muutuvad kasutatavaks ka rakenduse lisafunktsionaalsused ja värvide kohandamine.&lt;br&gt;&lt;br&gt;Aitäh!</string>
     <string name="update_thank_you">Palun uuenda rakendus Fossify Suur Tänu viimase versioonini</string>
@@ -1059,7 +1059,7 @@
     <string name="enter_password">Sisesta salasõna</string>
     <string name="password">Salasõna</string>
     <string name="add_password">Lisa salasõna</string>
-    <string name="seconds_letter">s</string>
+    <string name="seconds_letter">%ds</string>
     <string name="week_number_short">nd.</string>
     <string name="notification_sound">Teavituse heli</string>
     <string name="usb">USB</string>

--- a/commons/src/main/res/values-eu/strings.xml
+++ b/commons/src/main/res/values-eu/strings.xml
@@ -911,9 +911,9 @@
     <string name="enter_password">Sartu pasahitza</string>
     <string name="password">Pasahitza</string>
     <string name="add_password">Gehitu pasahitza</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">m</string>
-    <string name="hours_letter">ordu</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dm</string>
+    <string name="hours_letter">%dordu</string>
     <string name="week_number_short">aste</string>
     <string name="general_settings">Orokorra</string>
     <string name="list_view">Zerrenda ikuspegia</string>

--- a/commons/src/main/res/values-fa/strings.xml
+++ b/commons/src/main/res/values-fa/strings.xml
@@ -259,9 +259,9 @@
     <string name="minutes_raw">دقیقه</string>
     <string name="hours_raw">ساعت</string>
     <string name="days_raw">روز</string>
-    <string name="seconds_letter">ث</string>
-    <string name="minutes_letter">د</string>
-    <string name="hours_letter">س</string>
+    <string name="seconds_letter">%dث</string>
+    <string name="minutes_letter">%dد</string>
+    <string name="hours_letter">%dس</string>
     <plurals name="seconds">
         <item quantity="one">%d ثانیه</item>
         <item quantity="other">%d ثانیه</item>

--- a/commons/src/main/res/values-fi/strings.xml
+++ b/commons/src/main/res/values-fi/strings.xml
@@ -1049,9 +1049,9 @@
     <string name="deletion_confirmation_short">Poistetaanko %s?</string>
     <string name="pin">PIN</string>
     <string name="add_password">Lisää salasana</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">m</string>
-    <string name="hours_letter">t</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dm</string>
+    <string name="hours_letter">%dt</string>
     <string name="week_number_short">vko</string>
     <string name="october_short">Lok</string>
     <string name="november_short">Mar</string>

--- a/commons/src/main/res/values-fr/strings.xml
+++ b/commons/src/main/res/values-fr/strings.xml
@@ -476,7 +476,7 @@
     <string name="seconds_raw">secondes</string>
     <string name="hours_raw">heures</string>
     <string name="days_raw">jours</string>
-    <string name="minutes_letter">min</string>
+    <string name="minutes_letter">%dmin</string>
     <string name="week_number_short">sem</string>
     <plurals name="seconds">
         <item quantity="one">%d seconde</item>
@@ -1115,8 +1115,8 @@ j\'espère que vous appréciez l\'application. Elle ne contient pas d\'annonces,
     <string name="shared_theme_note">Notez que même si vous utilisez la version Pro de l\'application, vous avez toujours besoin de Fossify Thank You pour des raisons techniques. Il s\'occupe de la synchronisation des couleurs.</string>
     <string name="extension">Extension</string>
     <string name="minutes_raw">minutes</string>
-    <string name="seconds_letter">s</string>
-    <string name="hours_letter">h</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="hours_letter">%dh</string>
     <string name="purchase_simple_thank_you">Acheter Fossify Thank You</string>
     <string name="widgets">Widgets</string>
     <string name="contacts_tab">Contacts</string>

--- a/commons/src/main/res/values-ga/strings.xml
+++ b/commons/src/main/res/values-ga/strings.xml
@@ -964,9 +964,9 @@
     <string name="minutes_raw">nóiméad</string>
     <string name="hours_raw">uair an chloig</string>
     <string name="days_raw">laethanta</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">m</string>
-    <string name="hours_letter">h</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dm</string>
+    <string name="hours_letter">%dh</string>
     <string name="week_number_short">wk.</string>
     <string name="reminder_triggers_in">An t-am atá fágtha go dtí go spreagann an meabhrúchán:\n%s</string>
     <string name="time_remaining">An t-am atá fágtha:\n%s</string>

--- a/commons/src/main/res/values-hi-rIN/strings.xml
+++ b/commons/src/main/res/values-hi-rIN/strings.xml
@@ -675,13 +675,13 @@
     <string name="invalid_password">गलत पासवर्ड</string>
     <string name="yesterday">कल</string>
     <string name="today">आज</string>
-    <string name="seconds_letter">से</string>
+    <string name="seconds_letter">%dसे</string>
     <plurals name="days">
         <item quantity="one">%d दिन</item>
         <item quantity="other">%d दिन</item>
     </plurals>
-    <string name="minutes_letter">मि</string>
-    <string name="hours_letter">घं</string>
+    <string name="minutes_letter">%dमि</string>
+    <string name="hours_letter">%dघं</string>
     <string name="week_number_short">सप्त</string>
     <plurals name="seconds">
         <item quantity="one">%d सेकेंड</item>

--- a/commons/src/main/res/values-hr/strings.xml
+++ b/commons/src/main/res/values-hr/strings.xml
@@ -450,7 +450,7 @@
     <string name="minutes_raw">minute</string>
     <string name="hours_raw">sati</string>
     <string name="days_raw">dani</string>
-    <string name="minutes_letter">min</string>
+    <string name="minutes_letter">%dmin</string>
     <string name="week_number_short">tj.</string>
     <plurals name="seconds">
         <item quantity="one">%d sekunda</item>
@@ -1098,8 +1098,8 @@
     <string name="pin">PIN</string>
     <string name="too_many_incorrect_attempts">Previše netočnih pokušaja otključavanja.
 \nPokušaj ponovo za %d sekunde.</string>
-    <string name="seconds_letter">s</string>
-    <string name="hours_letter">h</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="hours_letter">%dh</string>
     <string name="alarm">Alarm</string>
     <string name="start_week_on">Početak tjedna je</string>
     <string name="files_tab">Datoteke</string>

--- a/commons/src/main/res/values-hu/strings.xml
+++ b/commons/src/main/res/values-hu/strings.xml
@@ -468,9 +468,9 @@
     <string name="minutes_raw">perc</string>
     <string name="hours_raw">óra</string>
     <string name="days_raw">nap</string>
-    <string name="seconds_letter">mp</string>
-    <string name="minutes_letter">p</string>
-    <string name="hours_letter">ó</string>
+    <string name="seconds_letter">%dmp</string>
+    <string name="minutes_letter">%dp</string>
+    <string name="hours_letter">%dó</string>
     <plurals name="seconds">
         <item quantity="one">%d másodperc</item>
         <item quantity="other">%d másodperc</item>

--- a/commons/src/main/res/values-in/strings.xml
+++ b/commons/src/main/res/values-in/strings.xml
@@ -972,9 +972,9 @@
     <string name="add_password">Tambahkan kata sandi</string>
     <string name="empty_password">Silakan masukkan kata sandi</string>
     <string name="invalid_password">Kata sandi alah</string>
-    <string name="seconds_letter">d</string>
-    <string name="minutes_letter">m</string>
-    <string name="hours_letter">j</string>
+    <string name="seconds_letter">%dd</string>
+    <string name="minutes_letter">%dm</string>
+    <string name="hours_letter">%dj</string>
     <string name="week_number_short">mg.</string>
     <string name="alarm">Alarm</string>
     <string name="purchase_simple_thank_you">Beli Terima Kasih Fossify</string>

--- a/commons/src/main/res/values-it/strings.xml
+++ b/commons/src/main/res/values-it/strings.xml
@@ -466,7 +466,7 @@
     <string name="minutes_raw">minuti</string>
     <string name="hours_raw">ore</string>
     <string name="days_raw">giorni</string>
-    <string name="hours_letter">o</string>
+    <string name="hours_letter">%do</string>
     <plurals name="seconds">
         <item quantity="one">%d secondo</item>
         <item quantity="many">%d secondi</item>
@@ -1114,8 +1114,8 @@
     <string name="no">No</string>
     <string name="pin">PIN</string>
     <string name="enter_password">Inserisci la password</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">m</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dm</string>
     <string name="notification_sound">Suono di notifica</string>
     <string name="january_short">Gen</string>
     <string name="copyright">v %1$s

--- a/commons/src/main/res/values-iw/strings.xml
+++ b/commons/src/main/res/values-iw/strings.xml
@@ -421,8 +421,8 @@
     <string name="password">סיסמה</string>
     <string name="empty_password_new">נא להזין סיסמה</string>
     <string name="invalid_password">הסיסמה שגויה</string>
-    <string name="seconds_letter">שנ\'</string>
-    <string name="minutes_letter">דק\'</string>
+    <string name="seconds_letter">%dשנ\'</string>
+    <string name="minutes_letter">%dדק\'</string>
     <string name="general_settings">כללי</string>
     <string name="color_customization">התאמה אישית של הצבעים</string>
     <string name="notification_sound">צליל התראה</string>
@@ -465,7 +465,7 @@
         <item quantity="two">%d שבועות</item>
         <item quantity="other">%d שבועות</item>
     </plurals>
-    <string name="hours_letter">שע\'</string>
+    <string name="hours_letter">%dשע\'</string>
     <string name="start_week_on">השבוע מתחיל ביום</string>
     <string name="snooze">נודניק</string>
     <string name="snooze_time">מרווח זמן הנודניק</string>

--- a/commons/src/main/res/values-ja/strings.xml
+++ b/commons/src/main/res/values-ja/strings.xml
@@ -920,7 +920,7 @@
     <string name="unblock_contact_fail">連絡先のブロックを解除できませんでした</string>
     <string name="block_contact_fail">連絡先をブロックできませんでした</string>
     <string name="show_line_numbers">行番号を表示</string>
-    <string name="hours_letter">時間</string>
+    <string name="hours_letter">%d時間</string>
     <string name="theme_and_colors">テーマと色</string>
     <string name="skip_the_recycle_bin">ごみ箱に入れずに直接ファイルを削除</string>
     <string name="copyright">v %1$s
@@ -984,8 +984,8 @@
     <string name="translation_chinese_tw">中国語（繁体字）</string>
     <string name="unblock_contact">連絡先のブロックを解除</string>
     <string name="block_hidden_messages">隠している番号からのメッセージをブロック</string>
-    <string name="seconds_letter">秒</string>
-    <string name="minutes_letter">分</string>
+    <string name="seconds_letter">%d秒</string>
+    <string name="minutes_letter">%d分</string>
     <string name="translation_ukrainian">ウクライナ語</string>
     <string name="translation_vietnamese">ベトナム語</string>
     <string name="close">閉じる</string>

--- a/commons/src/main/res/values-lt/strings.xml
+++ b/commons/src/main/res/values-lt/strings.xml
@@ -403,9 +403,9 @@
     <string name="minutes_raw">minutės</string>
     <string name="hours_raw">valandos</string>
     <string name="days_raw">dienos</string>
-    <string name="seconds_letter">sek.</string>
-    <string name="minutes_letter">min.</string>
-    <string name="hours_letter">val.</string>
+    <string name="seconds_letter">%dsek.</string>
+    <string name="minutes_letter">%dmin.</string>
+    <string name="hours_letter">%dval.</string>
     <plurals name="seconds">
         <item quantity="one">%d sekundė</item>
         <item quantity="few">%d sekundės</item>

--- a/commons/src/main/res/values-nb-rNO/strings.xml
+++ b/commons/src/main/res/values-nb-rNO/strings.xml
@@ -283,7 +283,7 @@
     <string name="minutes_raw">minutter</string>
     <string name="hours_raw">timer</string>
     <string name="days_raw">dager</string>
-    <string name="hours_letter">t</string>
+    <string name="hours_letter">%dt</string>
     <plurals name="seconds">
         <item quantity="one">%d sekund</item>
         <item quantity="other">%d sekunder</item>
@@ -546,12 +546,12 @@
     <string name="file_manager_short">Filbehandler</string>
     <string name="every_day">Hver dag</string>
     <string name="album">Album</string>
-    <string name="minutes_letter">m</string>
+    <string name="minutes_letter">%dm</string>
     <string name="notes_short">Notater</string>
     <string name="ok">OK</string>
     <string name="artist">Artist</string>
     <string name="genre">Genre</string>
-    <string name="seconds_letter">s</string>
+    <string name="seconds_letter">%ds</string>
     <string name="week_number_short">u.</string>
     <string name="alarm">Alarm</string>
     <string name="language">Språk</string>

--- a/commons/src/main/res/values-nl/strings.xml
+++ b/commons/src/main/res/values-nl/strings.xml
@@ -449,7 +449,7 @@
     <string name="minutes_raw">minuten</string>
     <string name="hours_raw">uren</string>
     <string name="days_raw">dagen</string>
-    <string name="hours_letter">u</string>
+    <string name="hours_letter">%du</string>
     <plurals name="seconds">
         <item quantity="one">%d seconde</item>
         <item quantity="other">%d seconden</item>
@@ -992,8 +992,8 @@
     <string name="app_icon_color_warning">Let op: Sommige launchers verwerken het aanpassen van het icoon mogelijk niet goed. Als het icoon verdwijnt, probeer dan de app te starten via Google Play, F-Droid of een widget. Herstel na het starten de groene standaardkleur #106D1F. In extreme gevallen kan het zijn dat de app opnieuw geïnstalleerd moet worden.</string>
     <string name="copyright">v %1$s
 \nCopyright © Fossify %2$d</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">m</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dm</string>
     <string name="week_number_short">wk.</string>
     <string name="alarm">Alarm</string>
     <string name="widgets">Widgets</string>

--- a/commons/src/main/res/values-pa-rPK/strings.xml
+++ b/commons/src/main/res/values-pa-rPK/strings.xml
@@ -366,9 +366,9 @@
     <string name="minutes_raw">منٹ</string>
     <string name="hours_raw">گھنٹے</string>
     <string name="days_raw">دن</string>
-    <string name="seconds_letter">سکنٹ</string>
-    <string name="minutes_letter">منٹ</string>
-    <string name="hours_letter">گھنٹے</string>
+    <string name="seconds_letter">%dسکنٹ</string>
+    <string name="minutes_letter">%dمنٹ</string>
+    <string name="hours_letter">%dگھنٹے</string>
     <plurals name="seconds">
         <item quantity="one">‫%d‬ ؜سکنٹ</item>
         <item quantity="other">‫%d‬ ؜سکنٹ</item>

--- a/commons/src/main/res/values-pl/strings.xml
+++ b/commons/src/main/res/values-pl/strings.xml
@@ -1146,9 +1146,9 @@
     <string name="album">Album</string>
     <string name="exif">EXIF</string>
     <string name="pin">PIN</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">m</string>
-    <string name="hours_letter">h</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dm</string>
+    <string name="hours_letter">%dh</string>
     <string name="usb">USB</string>
     <string name="march_short">mar</string>
     <string name="saturday_letter">S</string>

--- a/commons/src/main/res/values-pt-rBR/strings.xml
+++ b/commons/src/main/res/values-pt-rBR/strings.xml
@@ -972,9 +972,9 @@
     <string name="password">Senha</string>
     <string name="add_password">Adicionar senha</string>
     <string name="empty_password_new">Por favor, digite uma senha</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">m</string>
-    <string name="hours_letter">h</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dm</string>
+    <string name="hours_letter">%dh</string>
     <string name="notification_sound">Som de notificação</string>
     <string name="skip_the_recycle_bin">Excluir imediatamente e ignorar a lixeira</string>
     <string name="june_short">Jun</string>

--- a/commons/src/main/res/values-pt/strings.xml
+++ b/commons/src/main/res/values-pt/strings.xml
@@ -1000,7 +1000,7 @@
     <string name="developer_description">Uma gama de aplicações para Android, open source, com widgets personalizados, sem anúncios nem permissões desnecessárias.</string>
     <string name="too_many_incorrect_attempts">Introduziu o código errado várias vezes.
 \nTente novamente dentro de %d segundos.</string>
-    <string name="hours_letter">h</string>
+    <string name="hours_letter">%dh</string>
     <string name="why_upgrade_many_other_improvements">Muitas mais melhorias</string>
     <string name="purchase_simple_thank_you">Comprar Fossify Thank You</string>
     <string name="add_password">Adicionar palavra-passe</string>
@@ -1046,8 +1046,8 @@
     <string name="password">Palavra-passe</string>
     <string name="empty_password">Por favor introduza uma palavra-passe</string>
     <string name="invalid_password">Palavra-passe inválida</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">m</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dm</string>
     <string name="week_number_short">sem</string>
     <string name="snooze">Silenciar</string>
     <string name="notification_sound">Som da notificação</string>

--- a/commons/src/main/res/values-ru/strings.xml
+++ b/commons/src/main/res/values-ru/strings.xml
@@ -485,9 +485,9 @@
     <string name="minutes_raw">минут</string>
     <string name="hours_raw">часов</string>
     <string name="days_raw">дней</string>
-    <string name="seconds_letter">с</string>
-    <string name="minutes_letter">мин</string>
-    <string name="hours_letter">ч</string>
+    <string name="seconds_letter">%dс</string>
+    <string name="minutes_letter">%dмин</string>
+    <string name="hours_letter">%dч</string>
     <string name="week_number_short">нед.</string>
     <plurals name="seconds">
         <item quantity="one">%d секунда</item>

--- a/commons/src/main/res/values-ta/strings.xml
+++ b/commons/src/main/res/values-ta/strings.xml
@@ -227,9 +227,9 @@
     <string name="minutes_raw">நிமிடங்கள்</string>
     <string name="hours_raw">மணிநேரங்கள்</string>
     <string name="days_raw">நாட்கள்</string>
-    <string name="seconds_letter">வி</string>
-    <string name="minutes_letter">நி</string>
-    <string name="hours_letter">ம</string>
+    <string name="seconds_letter">%dவி</string>
+    <string name="minutes_letter">%dநி</string>
+    <string name="hours_letter">%dம</string>
     <plurals name="seconds">
         <item quantity="one">%d விநாடி</item>
         <item quantity="other">%d விநாடிகள்</item>

--- a/commons/src/main/res/values-tr/strings.xml
+++ b/commons/src/main/res/values-tr/strings.xml
@@ -471,9 +471,9 @@
     <string name="minutes_raw">dakika</string>
     <string name="hours_raw">saat</string>
     <string name="days_raw">gün</string>
-    <string name="seconds_letter">sn</string>
-    <string name="minutes_letter">dk</string>
-    <string name="hours_letter">sa</string>
+    <string name="seconds_letter">%dsn</string>
+    <string name="minutes_letter">%ddk</string>
+    <string name="hours_letter">%dsa</string>
     <string name="week_number_short">ha.</string>
     <plurals name="seconds">
         <item quantity="one">%d saniye</item>

--- a/commons/src/main/res/values-uk/strings.xml
+++ b/commons/src/main/res/values-uk/strings.xml
@@ -483,9 +483,9 @@
     <string name="minutes_raw">хвилин</string>
     <string name="hours_raw">годин</string>
     <string name="days_raw">днів</string>
-    <string name="seconds_letter">с</string>
-    <string name="minutes_letter">х</string>
-    <string name="hours_letter">г</string>
+    <string name="seconds_letter">%dс</string>
+    <string name="minutes_letter">%dх</string>
+    <string name="hours_letter">%dг</string>
     <plurals name="seconds">
         <item quantity="one">%d секунда</item>
         <item quantity="few">%d секунди</item>

--- a/commons/src/main/res/values-vi/strings.xml
+++ b/commons/src/main/res/values-vi/strings.xml
@@ -772,9 +772,9 @@
     <string name="enter_password">Nhập mật khẩu</string>
     <string name="password">Mật khẩu</string>
     <string name="add_password">Thêm mật khẩu</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">p</string>
-    <string name="hours_letter">h</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dp</string>
+    <string name="hours_letter">%dh</string>
     <plurals name="seconds">
         <item quantity="other">%d giây</item>
     </plurals>

--- a/commons/src/main/res/values-zh-rCN/strings.xml
+++ b/commons/src/main/res/values-zh-rCN/strings.xml
@@ -993,9 +993,9 @@
     <string name="translation_german">德语</string>
     <string name="translation_greek">希腊语</string>
     <string name="translation_spanish">西班牙语</string>
-    <string name="seconds_letter">秒</string>
-    <string name="minutes_letter">分钟</string>
-    <string name="hours_letter">小时</string>
+    <string name="seconds_letter">%d秒</string>
+    <string name="minutes_letter">%d分钟</string>
+    <string name="hours_letter">%d小时</string>
     <string name="translation_basque">巴斯克语</string>
     <string name="translation_persian">波斯语</string>
     <string name="translation_finnish">芬兰语</string>

--- a/commons/src/main/res/values-zh-rTW/strings.xml
+++ b/commons/src/main/res/values-zh-rTW/strings.xml
@@ -933,9 +933,9 @@
     <string name="enter_password">輸入密碼</string>
     <string name="every_day">每天</string>
     <string name="hide_year">隱藏年份</string>
-    <string name="seconds_letter">秒</string>
-    <string name="minutes_letter">分</string>
-    <string name="hours_letter">小時</string>
+    <string name="seconds_letter">%d秒</string>
+    <string name="minutes_letter">%d分</string>
+    <string name="hours_letter">%d小時</string>
     <string name="week_number_short">週</string>
     <string name="time_remaining">剩餘時間：\n%s</string>
     <string name="quality">品質</string>

--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -538,10 +538,10 @@
     <string name="minutes_raw">minutes</string>
     <string name="hours_raw">hours</string>
     <string name="days_raw">days</string>
-    <string name="seconds_letter">s</string>
-    <string name="minutes_letter">m</string>
-    <string name="hours_letter">h</string>
-    <string name="days_letter">d</string>
+    <string name="seconds_letter">%ds</string>
+    <string name="minutes_letter">%dm</string>
+    <string name="hours_letter">%dh</string>
+    <string name="days_letter">%dd</string>
     <string name="week_number_short">wk.</string>
 
     <plurals name="seconds">
@@ -572,11 +572,6 @@
         <item quantity="one">%d year</item>
         <item quantity="other">%d years</item>
     </plurals>
-
-    <string name="seconds_short">%ds</string>
-    <string name="minutes_short">%dm</string>
-    <string name="hours_short">%dh</string>
-    <string name="days_short">%dd</string>
 
     <!-- For example: I will be there in 5 minutes -->
     <plurals name="in_seconds">

--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -541,6 +541,7 @@
     <string name="seconds_letter">s</string>
     <string name="minutes_letter">m</string>
     <string name="hours_letter">h</string>
+    <string name="days_letter">d</string>
     <string name="week_number_short">wk.</string>
 
     <plurals name="seconds">
@@ -571,6 +572,11 @@
         <item quantity="one">%d year</item>
         <item quantity="other">%d years</item>
     </plurals>
+
+    <string name="seconds_short">%ds</string>
+    <string name="minutes_short">%dm</string>
+    <string name="hours_short">%dh</string>
+    <string name="days_short">%dd</string>
 
     <!-- For example: I will be there in 5 minutes -->
     <plurals name="in_seconds">


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Added an extension function to format seconds to abbreviated time string

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes FossifyOrg/AppRepo" so that GitHub closes them when this PR is merged (note that each "Fixes #" should be in its own item). For Commons, it should always be in a format like "Fixes FossifyOrg/AppRepo#123" -->
- Fixes FossifyOrg/Phone#339

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Commons/blob/master/CONTRIBUTING.md).
