### PR TITLE
Add SHA-1 and SHA-256 digests

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/dialogs/PropertiesDialog.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/dialogs/PropertiesDialog.kt
@@ -15,6 +15,7 @@ import org.fossify.commons.helpers.*
 import org.fossify.commons.models.FileDirItem
 import org.fossify.commons.views.MyTextView
 import java.io.File
+import java.io.InputStream
 import java.util.*
 
 class PropertiesDialog : BasePropertiesDialog {
@@ -172,22 +173,62 @@ class PropertiesDialog : BasePropertiesDialog {
             }
 
             if (mActivity.baseConfig.appId.removeSuffix(".debug") == "org.fossify.filemanager") {
-                addProperty(R.string.md5, "…", R.id.properties_md5)
-                ensureBackgroundThread {
-                    val md5 = if (mActivity.isRestrictedSAFOnlyRoot(path)) {
-                        mActivity.contentResolver.openInputStream(mActivity.getAndroidSAFUri(path))?.md5()
-                    } else {
-                        File(path).md5()
-                    }
+                calculateAndDisplayHash(
+                    path = path,
+                    labelRes = R.string.md5,
+                    propertyId = R.id.properties_md5,
+                    hashInputStream = { inputStream -> inputStream.md5() },
+                    hashFile = { file -> file.md5() }
+                )
 
-                    mActivity.runOnUiThread {
-                        if (md5 != null) {
-                            (mDialogView.propertiesHolder.findViewById<LinearLayout>(R.id.properties_md5).findViewById<MyTextView>(R.id.property_value)).text =
-                                md5
-                        } else {
-                            mDialogView.propertiesHolder.findViewById<LinearLayout>(R.id.properties_md5).beGone()
-                        }
-                    }
+                calculateAndDisplayHash(
+                    path = path,
+                    labelRes = R.string.sha1,
+                    propertyId = R.id.properties_sha1,
+                    hashInputStream = { inputStream -> inputStream.sha1() },
+                    hashFile = { file -> file.sha1() }
+                )
+
+                calculateAndDisplayHash(
+                    path = path,
+                    labelRes = R.string.sha256,
+                    propertyId = R.id.properties_sha256,
+                    hashInputStream = { inputStream -> inputStream.sha256() },
+                    hashFile = { file -> file.sha256() }
+                )
+            }
+        }
+    }
+
+    /**
+     * Calculate and display hash as a property in the dialog box
+     * @param path Path of the file to check
+     * @param labelRes Label resource to display to the user, e.g. R.string.md5 or R.string.sha1
+     * @param propertyId Technical property, e.g. R.id.properties_md5 or R.id.properties_sha256
+     * @param hashInputStream Pass the result given an InputStream, e.g. { inputStream -> inputStream.md5() }
+     * @param hashFile Pass the result given a File, e.g. { file -> file.md5() }
+     */
+    private fun calculateAndDisplayHash(
+        path: String,
+        labelRes: Int,
+        propertyId: Int,
+        hashInputStream: (InputStream) -> String?,
+        hashFile: (File) -> String?
+    ) {
+        addProperty(labelRes, "…", propertyId)
+        ensureBackgroundThread {
+            val digest = if (mActivity.isRestrictedSAFOnlyRoot(path)) {
+                mActivity.contentResolver.openInputStream(mActivity.getAndroidSAFUri(path))?.let { hashInputStream(it) }
+            } else {
+                hashFile(File(path))
+            }
+
+            mActivity.runOnUiThread {
+                if (digest != null) {
+                    (mDialogView.propertiesHolder.findViewById<LinearLayout>(propertyId).findViewById<MyTextView>(R.id.property_value)).text =
+                        digest
+                } else {
+                    mDialogView.propertiesHolder.findViewById<LinearLayout>(propertyId).beGone()
                 }
             }
         }

--- a/commons/src/main/kotlin/org/fossify/commons/extensions/File.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/File.kt
@@ -153,3 +153,5 @@ fun File.getDigest(algorithm: String): String? {
 }
 
 fun File.md5() = this.getDigest(MD5)
+fun File.sha1() = this.getDigest(SHA1)
+fun File.sha256() = this.getDigest(SHA256)

--- a/commons/src/main/kotlin/org/fossify/commons/extensions/InputStream.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/InputStream.kt
@@ -1,6 +1,8 @@
 package org.fossify.commons.extensions
 
 import org.fossify.commons.helpers.MD5
+import org.fossify.commons.helpers.SHA1
+import org.fossify.commons.helpers.SHA256
 import java.io.InputStream
 import java.security.MessageDigest
 
@@ -19,3 +21,5 @@ fun InputStream.getDigest(algorithm: String): String {
 }
 
 fun InputStream.md5(): String = this.getDigest(MD5)
+fun InputStream.sha1(): String = this.getDigest(SHA1)
+fun InputStream.sha256(): String = this.getDigest(SHA256)

--- a/commons/src/main/kotlin/org/fossify/commons/helpers/Constants.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/helpers/Constants.kt
@@ -48,6 +48,8 @@ const val SMT_PRIVATE =
     "smt_private" // used at the contact source of local contacts hidden from other apps
 const val FIRST_GROUP_ID = 10000L
 const val MD5 = "MD5"
+const val SHA1 = "SHA-1"
+const val SHA256 = "SHA-256"
 const val SHORT_ANIMATION_DURATION = 150L
 val DARK_GREY = 0xFF333333.toInt()
 

--- a/commons/src/main/res/values/donottranslate.xml
+++ b/commons/src/main/res/values/donottranslate.xml
@@ -167,6 +167,8 @@
 
     <!-- Message digest algorithms -->
     <string name="md5">MD5</string>
+    <string name="sha1">SHA-1</string>
+    <string name="sha256">SHA-256</string>
 
     <string-array name="months">
         <item>@string/january</item>

--- a/commons/src/main/res/values/ids.xml
+++ b/commons/src/main/res/values/ids.xml
@@ -5,4 +5,6 @@
     <item name="properties_file_count" type="id"/>
     <item name="properties_last_modified" type="id"/>
     <item name="properties_md5" type="id"/>
+    <item name="properties_sha1" type="id"/>
+    <item name="properties_sha256" type="id"/>
 </resources>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [X] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
Properties dialog already shows MD5 value. Adding SHA-1 and SHA-256 digests, as two other popular digest options, so we don’t need to rely on another app to just verify the checksums of what we download. Other digests may be available in the Java implementation, but [only MD5, SHA-1 and SHA-256 are guaranteed to be available on the Java platform](https://docs.oracle.com/javase/8/docs/api/java/security/MessageDigest.html), so I didn’t care to implement others (I know that KDE file manager implements SHA-512 as a 4th option, for example, but I never saw it used).

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

The comparison was done with the current v1.0.1 release, so the color UI changes are unrelated to this PR (I only added SHA-1 and SHA-256 fields).

#### Before/After Screenshots/Screen Record
 <img alt="A screenshot before the changes" src="https://github.com/user-attachments/assets/10302b88-375a-4b62-a752-2a78b6867e2b" width=341 />  

<img alt="A screenshot after the changes (includes SHA-1 and SHA-256 fields)" src="https://github.com/user-attachments/assets/e4a46a88-5a96-4277-88a8-92d999e56d9f" width=247 />

_Edit by @naveensingh: triggered fossifybot._

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes FossifyOrg/AppRepo" so that GitHub closes them when this PR is merged (note that each "Fixes #" should be in its own item). For Commons, it should always be in a format like "Fixes FossifyOrg/AppRepo#123" -->
- Fixes FossifyOrg/File-Manager#149

#### Tests
I compared the SHA-1 and SHA-256 digests with what KDE file manager is showing for the same file, and confirmed they were the same.

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Commons/blob/master/CONTRIBUTING.md).
