### PR TITLE
fix: use sentence case for setting labels

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/compose/settings/SettingsTitleTextComponent.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/compose/settings/SettingsTitleTextComponent.kt
@@ -22,7 +22,7 @@ fun SettingsTitleTextComponent(
 ) {
     Box(modifier = Modifier.padding(top = SimpleTheme.dimens.padding.large)) {
         Text(
-            text = text.uppercase(),
+            text = text,
             modifier = modifier,
             color = color,
             fontSize = 14.sp,

--- a/commons/src/main/res/values/styles.xml
+++ b/commons/src/main/res/values/styles.xml
@@ -418,7 +418,6 @@
         <item name="android:paddingTop">@dimen/big_margin</item>
         <item name="android:paddingBottom">@dimen/medium_margin</item>
         <item name="android:textSize">@dimen/normal_text_size</item>
-        <item name="android:textAllCaps">true</item>
         <item name="android:textColor">?attr/colorPrimary</item>
     </style>
 


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Switched to sentence case for preference labels. More info [here](https://m3.material.io/foundations/content-design/style-guide/ux-writing-best-practices#fc5c2a78-f4bf-4d42-bdac-42ff80391129).

#### Before/After Screenshots/Screen Record
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->
<img alt="image" src="https://github.com/user-attachments/assets/567a4f67-0146-4d27-af4f-e37e97df8149" width=180 />
<img alt="image" src="https://github.com/user-attachments/assets/bd0e448b-8947-4aa1-89bf-dc690a8f0db3" width=180 />

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). -->
- Partially addresses https://github.com/FossifyOrg/General-Discussion/issues/328

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
