### PR TITLE
fix: apply global theme changes unconditionally

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/activities/CustomizationActivity.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/activities/CustomizationActivity.kt
@@ -691,16 +691,16 @@ class CustomizationActivity : BaseSimpleActivity() {
 
             canAccessGlobalConfig() -> {
                 binding.applyToAllSwitch.isChecked = true
+                updateColorTheme(getCurrentThemeId())
+                saveChanges(false)
                 ConfirmationDialog(
                     activity = this,
                     message = "",
                     messageId = R.string.global_theme_success,
                     positive = R.string.ok,
-                    negative = 0
-                ) {
-                    updateColorTheme(getCurrentThemeId())
-                    saveChanges(false)
-                }
+                    negative = 0,
+                    callback = {}
+                )
             }
 
             else -> {


### PR DESCRIPTION
Previously, the **Apply color to all Fossify apps** didn't work if the dialog message was dismissed.