### PR TITLE
fix: add MIME type for log files

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/extensions/String.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/String.kt
@@ -553,6 +553,7 @@ fun String.getMimeType(): String {
         put("library-ms", "application/windows-library+xml")
         put("lit", "application/x-ms-reader")
         put("loadtest", "application/xml")
+        put("log", "text/plain")
         put("lpk", "application/octet-stream")
         put("lsf", "video/x-la-asf")
         put("lst", "text/plain")


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Mapped `.log` files to `text/plain`

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). -->
- Fixes https://github.com/FossifyOrg/File-Manager/issues/231

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
