### PR TITLE
fix: update batch renaming strings to be super super clear

### DIFF
--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -213,11 +213,11 @@
     <string name="filename_invalid_characters_placeholder">Filename \'%s\' contains invalid characters</string>
     <string name="extension_cannot_be_empty">Extension cannot be empty</string>
     <string name="source_file_doesnt_exist">Source file %s doesn\'t exist</string>
-    <string name="prepend_filenames">Prepend filenames</string>
-    <string name="append_filenames">Append filenames</string>
+    <string name="prepend_filenames">Add text before filenames</string>
+    <string name="append_filenames">Add text after filenames</string>
     <string name="simple_renaming">Simple renaming</string>
     <string name="pattern_renaming">Pattern</string>
-    <string name="string_to_add">String to add</string>
+    <string name="string_to_add">Text to add</string>
     <string name="rename_date_time_pattern">%Y - year\n%M - month\n%D - day\n%h - hour\n%m - minute\n%s - second\n%i - number increasing from 1</string>
     <string name="filename_without_txt">Filename (without .txt)</string>
     <string name="filename_without_json">Filename (without .json)</string>


### PR DESCRIPTION

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Update batch renaming related strings to avoid confusion due to literal and contextual interpretations
	- **Prepend filenames** ➜ **Add text before filenames**
	- **Append filenames** ➜ **Add text after filenames**
	- **String to add** ➜ **Text to add**

#### Before/After Screenshots/Screen Record
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->
![Screenshot_2025-07-21-10-38-50-768_org fossify filemanager](https://github.com/user-attachments/assets/de77a9a1-9540-4e6a-80dd-61241fe92a8f)


#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/General-Discussion/issues/288

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
