### PR TITLE
fix: show non-syncable contact sources

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/helpers/ContactsHelper.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/helpers/ContactsHelper.kt
@@ -835,7 +835,7 @@ class ContactsHelper(val context: Context) {
 
         val accounts = AccountManager.get(context).accounts
         accounts.forEach {
-            if (ContentResolver.getIsSyncable(it, AUTHORITY) > 0) {
+            if (ContentResolver.getIsSyncable(it, AUTHORITY) >= 0) {
                 var publicName = it.name
                 if (it.type == TELEGRAM_PACKAGE) {
                     publicName = context.getString(R.string.telegram)


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Changed contact source filtering condition from `getIsSyncable(it, AUTHORITY) >= 0` to `getIsSyncable(it, AUTHORITY) > 0`. The account visibility is currently tied to syncability, and that leads to bugs (see https://github.com/FossifyOrg/Contacts/issues/339, https://github.com/FossifyOrg/Phone/issues/28).

This is a quick fix.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Contacts/issues/339 (I hope)

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ ] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
