### PR TITLE
fix: prevent `IndexOutOfBoundsException` when `Android/data` is missing

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/extensions/Context-storage.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/Context-storage.kt
@@ -87,12 +87,13 @@ fun Context.hasOTGConnected(): Boolean {
 
 fun Context.getStorageDirectories(): Array<String> {
     val paths = HashSet<String>()
-    val rawExternalStorage = System.getenv("EXTERNAL_STORAGE")
     val rawSecondaryStoragesStr = System.getenv("SECONDARY_STORAGE")
     val rawEmulatedStorageTarget = System.getenv("EMULATED_STORAGE_TARGET")
-    if (TextUtils.isEmpty(rawEmulatedStorageTarget)) {
-        getExternalFilesDirs(null).filterNotNull().map { it.absolutePath }
-            .mapTo(paths) { it.substring(0, it.indexOf("Android/data")) }
+    if (rawEmulatedStorageTarget.isNullOrEmpty()) {
+        val androidData = "Android/data"
+        getExternalFilesDirs(null)
+            .filterNotNull()
+            .mapTo(paths) { it.absolutePath.substringBefore(androidData) }
     } else {
         val path = Environment.getExternalStorageDirectory().absolutePath
         val folders = Pattern.compile("/").split(path)
@@ -106,14 +107,15 @@ fun Context.getStorageDirectories(): Array<String> {
 
         val rawUserId = if (isDigit) lastFolder else ""
         if (TextUtils.isEmpty(rawUserId)) {
-            paths.add(rawEmulatedStorageTarget!!)
+            paths.add(rawEmulatedStorageTarget)
         } else {
             paths.add(rawEmulatedStorageTarget + File.separator + rawUserId)
         }
     }
 
-    if (!TextUtils.isEmpty(rawSecondaryStoragesStr)) {
-        val rawSecondaryStorages = rawSecondaryStoragesStr!!.split(File.pathSeparator.toRegex()).dropLastWhile(String::isEmpty).toTypedArray()
+    if (!rawSecondaryStoragesStr.isNullOrEmpty()) {
+        val rawSecondaryStorages = rawSecondaryStoragesStr
+            .split(File.pathSeparator.toRegex()).dropLastWhile(String::isEmpty).toTypedArray()
         Collections.addAll(paths, *rawSecondaryStorages)
     }
     return paths.map { it.trimEnd('/') }.toTypedArray()


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Addressed crash in `Context.getStorageDirectories()` when there's no `Android/data` in path. 

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/General-Discussion/issues/358

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ ] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
