### PR TITLE
fix: respect use english preference in compose activities

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/activities/BaseComposeActivity.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/activities/BaseComposeActivity.kt
@@ -1,12 +1,24 @@
 package org.fossify.commons.activities
 
+import android.content.Context
 import androidx.activity.ComponentActivity
+import org.fossify.commons.extensions.baseConfig
+import org.fossify.commons.helpers.MyContextWrapper
 import org.fossify.commons.helpers.REQUEST_APP_UNLOCK
+import org.fossify.commons.helpers.isTiramisuPlus
 
 abstract class BaseComposeActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
         maybeLaunchAppUnlockActivity(REQUEST_APP_UNLOCK)
+    }
+
+    override fun attachBaseContext(newBase: Context) {
+        if (newBase.baseConfig.useEnglish && !isTiramisuPlus()) {
+            super.attachBaseContext(MyContextWrapper(newBase).wrap(newBase, "en"))
+        } else {
+            super.attachBaseContext(newBase)
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Attached a wrapped context when `useEnglish` is enabled. This was done in the BaseSimpleActivity but not in BaseComposeActivity.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/General-Discussion/issues/95
- Closes https://github.com/FossifyOrg/Thank-You/issues/75

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
