### PR TITLE
feat: rename delete to unblock in blocked numbers screen (#369)

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/compose/screens/ManageBlockedNumbersScreen.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/compose/screens/ManageBlockedNumbersScreen.kt
@@ -419,7 +419,7 @@ private fun BlockedNumberTrailingContent(modifier: Modifier = Modifier, onDelete
             dismissMenu()
         }, text = {
             Text(
-                text = stringResource(id = R.string.delete),
+                text = stringResource(id = R.string.unblock),
                 modifier = Modifier.fillMaxWidth(),
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Normal
@@ -513,11 +513,9 @@ private fun BlockedNumberActionMenu(
     val actionMenus = remember(selectedIdsCount) {
         val delete =
             ActionItem(
-                nameRes = R.string.delete,
-                icon = Icons.Default.Delete,
+                nameRes = R.string.unblock,
                 doAction = onDelete,
-                overflowMode = OverflowMode.NEVER_OVERFLOW,
-                iconColor = iconColor
+                overflowMode = OverflowMode.ALWAYS_OVERFLOW,
             )
 
         val list = if (selectedIdsCount == 1) {
@@ -536,7 +534,14 @@ private fun BlockedNumberActionMenu(
         }
         list.toImmutableList()
     }
-    ActionMenu(items = actionMenus, numIcons = if (selectedIdsCount == 1) 2 else 1, isMenuVisible = true, onMenuToggle = { }, iconsColor = iconColor)
+    var isMenuVisible by remember { mutableStateOf(false) }
+    ActionMenu(
+        items = actionMenus,
+        numIcons = if (selectedIdsCount == 1) 2 else 1,
+        isMenuVisible = isMenuVisible,
+        onMenuToggle = { isMenuVisible = it },
+        iconsColor = iconColor
+    )
 }
 
 @Composable


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Replaced `Delete` with `Unblock` in all places in Manage blocked numbers screen.
- Moved `Unblock` in top bar to the three dots menu.
- Tested both in Phone and Messages.

BTW. Manage blocked numbers screen is duplicated - there are an XML view with Activity and the Compose version. Can we remove the old Activity, or is it still used somewhere?

#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->

<img width="1280" height="2856" alt="Screenshot_1754809624" src="https://github.com/user-attachments/assets/88aa42f9-b015-49c3-beac-9a2f40221fad" />

<img width="1280" height="2856" alt="Screenshot_1754809637" src="https://github.com/user-attachments/assets/441b6013-6a86-4e78-b68a-85feb54452cb" />

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes FossifyOrg/General-Discussion#369

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
