### PR TITLE
ci: add `chore` to the semver patch list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
           branch: ${{ github.event.repository.default_branch }}
           noNewCommitBehavior: 'warn'
           noVersionBumpBehavior: 'warn'
+          patchList: fix, bugfix, perf, refactor, test, tests, chore
 
       - name: Create and push tag
         if: ${{ steps.version.outputs.nextStrict }}


### PR DESCRIPTION
Commons has different release constraints. This will help with translation-only releases.