### PR TITLE
fix: avoid resetting in-progress pattern gesture

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/views/PatternTab.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/views/PatternTab.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.ColorStateList
 import android.os.Handler
+import android.os.Looper
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.widget.TextView
@@ -106,13 +107,19 @@ class PatternTab(context: Context, attrs: AttributeSet) : BaseSecurityTab(contex
             else -> {
                 onIncorrectPassword()
                 binding.patternLockView.setViewMode(PatternLockView.PatternViewMode.WRONG)
-                Handler().postDelayed(delayInMillis = 1000) {
+                binding.patternLockView.isInputEnabled = false
+                Handler(Looper.getMainLooper()).postDelayed(WRONG_PATTERN_CLEAR_DELAY) {
                     binding.patternLockView.clearPattern()
+                    binding.patternLockView.isInputEnabled = !isLockedOut()
                     if (requiredHash.isEmpty()) {
                         computedHash = ""
                     }
                 }
             }
         }
+    }
+
+    companion object {
+        private const val WRONG_PATTERN_CLEAR_DELAY = 300L
     }
 }


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
 - Reduced the wrong pattern clear delay to 300ms. This is long enough to provide a noticeable error feedback to the user while being short enough not to interfere with the next attempt.
 - Disabled pattern input until the wrong pattern is cleared automatically (300ms). This adds a bit of natural delay before the user can retry, but it helps with https://github.com/FossifyOrg/General-Discussion/issues/709

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/General-Discussion/issues/709

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
