### PR TITLE
fix: trust the system to check whether a file is a directory

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/dialogs/FilePickerDialog.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/dialogs/FilePickerDialog.kt
@@ -305,7 +305,7 @@ class FilePickerDialog(
             val curName = curPath.getFilenameFromPath()
             val size = file.length()
             var lastModified = lastModifieds.remove(curPath)
-            val isDirectory = if (lastModified != null) false else file.isDirectory
+            val isDirectory = file.isDirectory
             if (lastModified == null) {
                 lastModified = 0    // we don't actually need the real lastModified that badly, do not check file.lastModified()
             }


### PR DESCRIPTION
Same fix as https://github.com/FossifyOrg/File-Manager/pull/261

Closes https://github.com/FossifyOrg/File-Manager/issues/267