### PR TITLE
fix: normalize MIME types when sharing

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/Activity.kt
@@ -444,7 +444,7 @@ fun Activity.sharePathIntent(path: String, applicationId: String) {
         Intent().apply {
             action = Intent.ACTION_SEND
             putExtra(EXTRA_STREAM, newUri)
-            type = getUriMimeType(path, newUri)
+            type = getUriMimeType(path, newUri).normalizeMimeTypeForSharing()
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             grantUriPermission("android", newUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
@@ -482,6 +482,7 @@ fun Activity.sharePathsIntent(paths: List<String>, applicationId: String) {
             if (mimeType.isEmpty() || mimeType == "*/*") {
                 mimeType = paths.getMimeType()
             }
+            mimeType = mimeType.normalizeMimeTypeForSharing()
 
             Intent().apply {
                 action = Intent.ACTION_SEND_MULTIPLE

--- a/commons/src/main/kotlin/org/fossify/commons/extensions/String.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/String.kt
@@ -941,6 +941,14 @@ fun String.getMimeType(): String {
     return typesMap[getFilenameExtension().lowercase(Locale.getDefault())] ?: ""
 }
 
+fun String?.normalizeMimeTypeForSharing(): String {
+    return if (isNullOrBlank() || this == "application/octet-stream") {
+        "*/*"
+    } else {
+        this
+    }
+}
+
 fun String.isBlockedNumberPattern() = contains("*")
 
 fun String?.fromHtml(): Spanned =


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
The sharing helpers now intentionally fall back to `*/*` when the MIME type is `application/octet-stream` or unknown. 

This should solve issues like https://github.com/FossifyOrg/File-Manager/issues/266, https://github.com/FossifyOrg/File-Manager/issues/231 for good.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Sharing files using File Manager.
 - Sharing a SQLite database file on Android 9

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/File-Manager/issues/266

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
