### PR TITLE
fix: remove stray space before suffix in contact display name

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/models/contacts/Contact.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/models/contacts/Contact.kt
@@ -173,9 +173,9 @@ data class Contact(
         }
         val lastPart = if (startWithSurname) firstMiddle else surname
         val suffixComma = if (suffix.isEmpty()) "" else ", $suffix"
-        val fullName = listOfNotNull(prefix, firstPart, "$lastPart$suffixComma")
+        val fullName = listOfNotNull(prefix, firstPart, lastPart)
             .filter { it.isNotBlank() }
-            .joinToString(" ")
+            .joinToString(" ") + suffixComma
         val organization = getFullCompany()
         val email = emails.firstOrNull()?.value?.trim()
         val phoneNumber = phoneNumbers.firstOrNull()?.normalizedNumber


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
`Contact.getNameToDisplay()` built the display name as `listOfNotNull(prefix, firstPart, "$lastPart$suffixComma").filter { it.isNotBlank() }.joinToString(" ")`. The `.filter { isNotBlank() }` already fixed the *double space* from an empty middle part (e.g. prefix + surname only), but when the last name is empty and a **suffix** is present, the third element becomes `", <suffix>"` — which is not blank, so it survives the filter and `joinToString(" ")` prepends a stray space, e.g. `John , Jr` / `Smith , Jr`.

Fix: make `lastPart` its own filterable element and append the suffix **after** the join, so an empty last name is dropped and the suffix comma is never preceded by a stray space.

This lives in commons because `getNameToDisplay()` is shared; it fixes the display name in Fossify Contacts and Phone (contact rows, details header, shortcuts, letter avatars).

#### Tests performed
Verified the pure `getNameToDisplay()` string logic against the reported and adjacent cases (before → after):
- `John` + suffix `Jr`: `John , Jr` → `John, Jr`
- start-with-surname `Smith` + suffix `Jr`: `Smith , Jr` → `Smith, Jr`
- prefix `Dr` + surname `Smith`: `Dr Smith` (unchanged)
- full `Dr John Smith Jr`: `Dr John Smith, Jr` (unchanged)

`./gradlew :commons:detekt :commons:lintRelease :commons:assembleRelease` all pass locally. (commons has no unit-test source set, so this is a static/logic verification.)

#### Related issue(s)
- Fixes FossifyOrg/Contacts#157 (the fix lives here in commons; the app issue can be closed once commons is bumped)

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually verified the affected logic.
- [x] I have self-reviewed my pull request.
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
