### PR TITLE
fix: guard takePersistableUriPermission against SecurityException when storing alarm sound

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
@@ -811,7 +811,12 @@ fun Context.storeNewYourAlarmSound(resultData: Intent): AlarmSound {
     baseConfig.yourAlarmSounds = Gson().toJson(yourAlarmSounds)
 
     val takeFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION
-    contentResolver.takePersistableUriPermission(uri, takeFlags)
+    try {
+        contentResolver.takePersistableUriPermission(uri, takeFlags)
+    } catch (_: SecurityException) {
+        // some file managers return a content uri without a persistable
+        // permission grant, which would otherwise crash the app
+    }
 
     return newAlarmSound
 }


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
`Context.storeNewYourAlarmSound()` calls `contentResolver.takePersistableUriPermission(uri, ...)` on the URI returned by the file picker. Some file managers (including cases reported against Fossify Clock) return a `content://` URI **without** a persistable permission grant, so `takePersistableUriPermission` throws `SecurityException` and the app crashes when the user picks a custom alarm/timer sound.

Fix: wrap the call in a `try/catch (_: SecurityException)`. The sound URI is still stored; only the (best-effort) persistable-permission grab is guarded. The catch is scoped narrowly to `SecurityException`, so it can only prevent the documented crash, never mask unrelated failures. The unused-exception form `catch (_: …)` follows the existing commons convention.

#### Tests performed
`./gradlew :commons:detekt :commons:lintRelease :commons:assembleRelease` all pass locally. This is a defensive guard around a call that currently throws in the reported scenario; by construction it cannot change behavior except to avoid the crash.

#### Related issue(s)
- Fixes FossifyOrg/Clock#267 (the fix lives here in commons; the app issue can be closed once commons is bumped)

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually verified the affected logic.
- [x] I have self-reviewed my pull request.
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
