### PR TITLE
fixed Context.getSelectedDaysString Array casting to AttayList.

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/extensions/Context.kt
@@ -633,7 +633,7 @@ fun Context.isPackageInstalled(pkgName: String): Boolean {
 // format day bits to strings like "Mon, Tue, Wed"
 fun Context.getSelectedDaysString(bitMask: Int): String {
     val dayBits = arrayListOf(MONDAY_BIT, TUESDAY_BIT, WEDNESDAY_BIT, THURSDAY_BIT, FRIDAY_BIT, SATURDAY_BIT, SUNDAY_BIT)
-    val weekDays = resources.getStringArray(R.array.week_days_short).toList() as ArrayList<String>
+    val weekDays = ArrayList(resources.getStringArray(R.array.week_days_short).toList())
 
     if (baseConfig.isSundayFirst) {
         dayBits.moveLastItemToFront()


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
I am working on a feature for the clock app that utilizes the `extensions.Context.getSelectedDaysString` function, but i found that the type casting (on line 636) was crashing/hanging when debuging the feature. To test why, i made a hack fix, implementing said function in the file i was working in and tried to change it to a safe convertion. I have introduced this fix in this PR, it is a simple one line fix. I am not sure why this has never been a problem before, but this change should not break anything.

#### Tests performed
This change should have no impact on performance on any device.

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ ] I manually tested my changes on device/emulator (not applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (not applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
