### PR TITLE
Keep the range-select anchor across taps in selection mode

### DIFF
--- a/commons/src/main/kotlin/org/fossify/commons/adapters/MyRecyclerViewAdapter.kt
+++ b/commons/src/main/kotlin/org/fossify/commons/adapters/MyRecyclerViewAdapter.kt
@@ -335,10 +335,18 @@ abstract class MyRecyclerViewAdapter(val activity: BaseSimpleActivity, val recyc
                 val currentPosition = adapterPosition - positionOffset
                 val isSelected = selectedKeys.contains(getItemSelectionKey(currentPosition))
                 toggleItemSelection(!isSelected, currentPosition, true)
+                // While in selection mode, remember the tapped row as the range anchor so a following
+                // long-press selects every row between it and the long-pressed row. Previously the anchor
+                // was always cleared here, so range selection only worked across two *consecutive*
+                // long-presses; tapping a row in between (to select or skip it) reset the anchor and the
+                // next long-press selected only its single row. Tracking the last touched row instead lets
+                // "tap a row, then long-press a later row" fill in everything between.
+                lastLongPressedItem = currentPosition
             } else {
                 itemClick.invoke(any)
+                // not in selection mode: no anchor to keep
+                lastLongPressedItem = -1
             }
-            lastLongPressedItem = -1
         }
 
         fun viewLongClicked() {


### PR DESCRIPTION
## Problem

Range selection via long-press only works across **two consecutive long-presses**. As soon as the user *taps* a row in between (to select or skip it), the range anchor is lost and the next long-press selects only its own single row.

Concretely, `MyRecyclerViewAdapter.viewClicked()` always reset `lastLongPressedItem = -1` at the end — including when the tap happened *inside* selection mode. So the common gesture:

1. tap a row to select it,
2. long-press a row several positions later expecting the rows in between to be selected,

does not fill the range, because the tap in step 1 already cleared the anchor. The same applies to “select one, skip one, select the next, then long-press further”.

## Fix

While in selection mode, remember the tapped row as the range anchor instead of clearing it. A following long-press then fills in every row between the last touched row and the long-pressed row (which is exactly what `itemLongClicked()` already does when an anchor exists). Outside selection mode the anchor is cleared as before, so normal single-tap navigation is unchanged.

```kotlin
fun viewClicked(any: Any) {
    if (actModeCallback.isSelectable) {
        val currentPosition = adapterPosition - positionOffset
        val isSelected = selectedKeys.contains(getItemSelectionKey(currentPosition))
        toggleItemSelection(!isSelected, currentPosition, true)
        lastLongPressedItem = currentPosition   // keep the tap as the range anchor
    } else {
        itemClick.invoke(any)
        lastLongPressedItem = -1
    }
}
```

## Behaviour / edge cases

- **Not in selection mode:** unchanged — `itemClick` fires and the anchor is cleared.
- **Non-selectable positions** (section headers etc.): still skipped, because `toggleItemSelection()` returns early for `!getIsItemSelectable(pos)`, so the range fill only affects selectable rows.
- **Drag-select** (finger drag): unaffected — `selectItemRange()` resets `lastLongPressedItem` itself after a drag.
- **Direction:** `itemLongClicked()` uses `min`/`max`, so ranges fill both upward and downward.
- **Deselect via tap:** the anchor also moves to a row that was just *deselected*, so a following long-press ranges from there — which reads as “range from where I last touched”.

## Testing

Verified by tracing every gesture path in `viewClicked` / `viewLongClicked` / `itemLongClicked` / `toggleItemSelection` / the drag path. A single-adapter behavioural change with no effect on non-selection navigation or drag-select.
